### PR TITLE
Auto install & build client when installing server

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "svelte-app",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "sirv-cli": "^1.0.0",
         "socket.io-client": "^4.0.1"

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "start": "sirv public --no-clear --cors",
-    "validate": "svelte-check"
+    "validate": "svelte-check",
+    "postinstall": "npm run build"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "ts-node-dev index.ts",
     "build": "tsc",
-    "start": "node index.js"
+    "start": "node index.js",
+		"postinstall": "npm install --prefix ../client/"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Instead of

1. installing the server
2. running the server
3. installing the client
4. building the client

I added a postinstalls that only require you to run `npm i` in the server directory.